### PR TITLE
Add ember-cli-babel to allow transpilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "bower-json": "^0.8.1",
+    "ember-cli-babel": "^6.11.0",
     "ember-cli-htmlbars": "^1.0.10",
     "license-checker": "^8.0.3",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Addons need to have `ember-cli-babel` in their dependencies to allow them to be properly transpiled according to: https://github.com/ember-cli/ember-cli/issues/3556